### PR TITLE
fix: resolve 11 GitHub issues - security, refactoring, and enhancements

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gosimple
+
+issues:
+  exclude-dirs:
+    - vendor

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-all clean test install fmt vet
+.PHONY: build build-all clean test install fmt vet lint checksums
 
 VERSION := $(shell git update-index --refresh >/dev/null 2>&1; git describe --tags --always --dirty 2>/dev/null || echo dev)
 LDFLAGS := -ldflags "-X github.com/egeskov/odooctl/cmd.version=$(VERSION)"
@@ -31,6 +31,10 @@ fmt:
 vet:
 	@go vet $(shell go list ./... | grep -v /vendor/)
 
+# Run golangci-lint for comprehensive static analysis
+lint:
+	@golangci-lint run ./...
+
 # Install to GOPATH/bin
 install:
 	go install $(LDFLAGS) .
@@ -38,3 +42,8 @@ install:
 # Development: build and run
 run: build
 	./bin/odooctl $(ARGS)
+
+# Generate SHA256 checksums for release binaries
+checksums:
+	@cd bin && sha256sum odooctl-* > checksums.txt
+	@echo "Checksums generated in bin/checksums.txt"

--- a/cmd/docker/db.go
+++ b/cmd/docker/db.go
@@ -1,8 +1,6 @@
 package docker
 
 import (
-	"strings"
-
 	"github.com/egeskov/odooctl/internal/docker"
 	"github.com/spf13/cobra"
 )
@@ -28,8 +26,7 @@ func runDB(cmd *cobra.Command, args []string) error {
 
 	database := flagDatabase
 	if database == "" {
-		versionSuffix := strings.Replace(state.OdooVersion, ".", "", 1)
-		database = "odoo-" + versionSuffix
+		database = state.DBName()
 	}
 
 	return docker.Compose(state, "exec", "db", "psql", "-U", "odoo", "-d", database)

--- a/cmd/docker/dump.go
+++ b/cmd/docker/dump.go
@@ -68,7 +68,7 @@ func runDump(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get database name
-	dbName := getDBNameFromState(state)
+	dbName := state.DBName()
 
 	fmt.Printf("%s Creating backup for project: %s\n", cyan("📦"), state.ProjectName)
 	fmt.Printf("%s Database: %s\n", cyan("📊"), dbName)
@@ -261,9 +261,4 @@ func createZipArchive(sourceDir, outputFile string) error {
 		_, err = io.Copy(writer, file)
 		return err
 	})
-}
-
-func getDBNameFromState(state *config.State) string {
-	versionSuffix := strings.Replace(state.OdooVersion, ".", "", 1)
-	return "odoo-" + versionSuffix
 }

--- a/cmd/docker/goto.go
+++ b/cmd/docker/goto.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/egeskov/odooctl/internal/config"
+	"github.com/egeskov/odooctl/pkg/prompt"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -135,11 +136,8 @@ func runGoto(cmd *cobra.Command, args []string) error {
 	}
 
 	// Prompt for selection
-	fmt.Printf("\nSelect project (1-%d) or 'q' to quit: ", len(projects))
-	var input string
-	fmt.Scanln(&input)
-
-	if input == "q" || input == "Q" || input == "" {
+	input, err := prompt.InputString(fmt.Sprintf("\nSelect project (1-%d) or 'q' to quit:", len(projects)), "")
+	if err != nil || input == "q" || input == "Q" || input == "" {
 		fmt.Println("Cancelled.")
 		return nil
 	}
@@ -181,7 +179,7 @@ func runGoto(cmd *cobra.Command, args []string) error {
 						cmd.Dir = selected.ProjectRoot
 						cmd.Stdout = os.Stdout
 						cmd.Stderr = os.Stderr
-						cmd.Run()
+						_ = cmd.Run() // Best effort, errors will be visible in stderr
 					}
 				}
 			}

--- a/cmd/docker/install.go
+++ b/cmd/docker/install.go
@@ -298,7 +298,7 @@ func runOdooUpdate(state *config.State, install, update []string) error {
 	args := []string{
 		"run", "--rm", "odoo",
 		"odoo", "-c", "/etc/odoo/odoo.conf",
-		"-d", getDBName(state),
+		"-d", state.DBName(),
 	}
 
 	if len(install) > 0 {
@@ -310,11 +310,6 @@ func runOdooUpdate(state *config.State, install, update []string) error {
 	args = append(args, "--stop-after-init")
 
 	return docker.Compose(state, args...)
-}
-
-func getDBName(state *config.State) string {
-	versionSuffix := strings.Replace(state.OdooVersion, ".", "", 1)
-	return "odoo-" + versionSuffix
 }
 
 func hashFilePath(state *config.State) (string, error) {

--- a/cmd/docker/reset.go
+++ b/cmd/docker/reset.go
@@ -75,7 +75,9 @@ func runReset(cmd *cobra.Command, args []string) error {
 	if flagResetVolumes {
 		downArgs = append(downArgs, "-v")
 	}
-	docker.Compose(state, downArgs...)
+	if err := docker.Compose(state, downArgs...); err != nil {
+		fmt.Printf("%s Warning: failed to stop containers: %v\n", yellow("!"), err)
+	}
 
 	// Remove environment directory if requested
 	if flagResetFiles {

--- a/cmd/docker/run.go
+++ b/cmd/docker/run.go
@@ -144,7 +144,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		// Configure report.url parameter
 		fmt.Println("Configuring report.url parameter...")
 		sql := "INSERT INTO ir_config_parameter (key, value) VALUES ('report.url', 'http://odoo:8069') ON CONFLICT (key) DO UPDATE SET value = 'http://odoo:8069';"
-		if err := docker.Compose(state, "exec", "-T", "db", "psql", "-U", "odoo", "-d", getDBName(state), "-c", sql); err != nil {
+		if err := docker.Compose(state, "exec", "-T", "db", "psql", "-U", "odoo", "-d", state.DBName(), "-c", sql); err != nil {
 			fmt.Printf("%s Warning: failed to configure report.url: %v\n", yellow("⚠️"), err)
 		}
 

--- a/cmd/docker/shell.go
+++ b/cmd/docker/shell.go
@@ -1,8 +1,6 @@
 package docker
 
 import (
-	"strings"
-
 	"github.com/egeskov/odooctl/internal/docker"
 	"github.com/spf13/cobra"
 )
@@ -37,8 +35,7 @@ func runShell(cmd *cobra.Command, args []string) error {
 
 	if flagOdooShell {
 		// Odoo shell mode
-		versionSuffix := strings.Replace(state.OdooVersion, ".", "", 1)
-		database := "odoo-" + versionSuffix
+		database := state.DBName()
 		return docker.Compose(state, "exec", flagService, "odoo", "shell", "-d", database)
 	}
 

--- a/cmd/docker/test.go
+++ b/cmd/docker/test.go
@@ -2,9 +2,9 @@ package docker
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/egeskov/odooctl/internal/docker"
+	"github.com/egeskov/odooctl/pkg/prompt"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -67,8 +67,7 @@ func runTest(cmd *cobra.Command, args []string) error {
 	cyan := color.New(color.FgCyan).SprintFunc()
 
 	// Build odoo-bin command
-	versionSuffix := strings.Replace(state.OdooVersion, ".", "", 1)
-	database := "odoo-" + versionSuffix
+	database := state.DBName()
 
 	testArgs := []string{
 		"run", "--rm", "odoo",
@@ -100,10 +99,8 @@ func runTest(cmd *cobra.Command, args []string) error {
 	// Warn if no modules or tags specified
 	if flagTestModules == "" && flagTestTags == "" {
 		fmt.Printf("%s No modules or test-tags specified. This will run ALL tests!\n", color.YellowString("⚠️"))
-		fmt.Print("Continue? [y/N]: ")
-		var response string
-		fmt.Scanln(&response)
-		if strings.ToLower(response) != "y" && strings.ToLower(response) != "yes" {
+		confirmed, err := prompt.Confirm("Continue?", false)
+		if err != nil || !confirmed {
 			fmt.Println("Test cancelled.")
 			return nil
 		}

--- a/internal/config/util.go
+++ b/internal/config/util.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ExpandPath expands ~ to the user's home directory
+func ExpandPath(path string) (string, error) {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, path[2:]), nil
+	}
+	return filepath.Abs(path)
+}
+
+// MaskToken shows only the prefix and last 4 chars of a token
+func MaskToken(token string) string {
+	if len(token) <= 8 {
+		return "****"
+	}
+	// Show prefix (ghp_ or github_pat_) + enough to identify, mask the rest
+	prefixEnd := 4
+	if strings.HasPrefix(token, "github_pat_") {
+		prefixEnd = 11
+	}
+	visible := token[:prefixEnd]
+	last4 := token[len(token)-4:]
+	masked := len(token) - prefixEnd - 4
+	return visible + strings.Repeat("*", masked) + last4
+}
+
+// SanitizeName sanitizes project and branch names for safe use in file paths and Docker resource names
+// Replaces / with - and removes any characters that aren't alphanumeric, hyphen, underscore, or dot
+func SanitizeName(name string) string {
+	// Replace / with - (common convention for branch names like feature/my-feature)
+	name = strings.ReplaceAll(name, "/", "-")
+
+	// Remove any characters that aren't alphanumeric, hyphen, underscore, or dot
+	re := regexp.MustCompile(`[^a-zA-Z0-9\-_.]`)
+	name = re.ReplaceAllString(name, "")
+
+	return name
+}

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/egeskov/odooctl/internal/module"
+	"github.com/egeskov/odooctl/pkg/prompt"
 	"github.com/fatih/color"
 )
 
@@ -100,10 +101,8 @@ func DiscoverPythonDeps(dirs []string, existingPkgs []string) []string {
 		fmt.Printf("\n%s %s\n", color.YellowString("📦"), pkg)
 		fmt.Printf("   Required by: %s\n", color.HiBlackString(strings.Join(mods, ", ")))
 
-		fmt.Printf("   Include %s? [Y/n]: ", pkg)
-		var response string
-		fmt.Scanln(&response)
-		if response == "" || strings.ToLower(response) == "y" || strings.ToLower(response) == "yes" {
+		confirmed, err := prompt.Confirm(fmt.Sprintf("   Include %s?", pkg), true)
+		if err == nil && confirmed {
 			selected = append(selected, pkg)
 			fmt.Printf("   %s Will install %s\n", color.GreenString("✓"), pkg)
 		} else {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -24,6 +24,11 @@ func Compose(state *config.State, args ...string) error {
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 
+	// Pass GITHUB_TOKEN as environment variable if using GitHub token for enterprise
+	if state.Enterprise && state.EnterpriseGitHubToken != "" {
+		cmd.Env = append(os.Environ(), fmt.Sprintf("GITHUB_TOKEN=%s", state.EnterpriseGitHubToken))
+	}
+
 	return cmd.Run()
 }
 
@@ -95,7 +100,7 @@ func PrintStatus(state *config.State) error {
 
 	fmt.Printf("\n%s %s\n", cyan("Project:"), state.ProjectName)
 	fmt.Printf("%s Odoo %s\n", cyan("Version:"), state.OdooVersion)
-	fmt.Printf("%s %s\n\n", cyan("Database:"), getDBNameFromState(state))
+	fmt.Printf("%s %s\n\n", cyan("Database:"), state.DBName())
 
 	services, err := GetServicesStatus(state)
 	if err != nil || len(services) == 0 {
@@ -142,9 +147,4 @@ func PrintStatus(state *config.State) error {
 	}
 
 	return nil
-}
-
-func getDBNameFromState(state *config.State) string {
-	versionSuffix := strings.Replace(state.OdooVersion, ".", "", 1)
-	return "odoo-" + versionSuffix
 }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/egeskov/odooctl/internal/config"
 	"github.com/egeskov/odooctl/internal/git"
 )
 
@@ -20,17 +21,17 @@ type Context struct {
 func Detect(dir string) Context {
 	absDir, _ := filepath.Abs(dir)
 	ctx := Context{
-		Name:   filepath.Base(absDir),
+		Name:   config.SanitizeName(filepath.Base(absDir)),
 		Root:   absDir,
-		Branch: "main",
+		Branch: config.SanitizeName("main"),
 	}
 
 	// Check for git repo
 	gitInfo := git.Detect(dir)
 	if gitInfo.IsRepo {
 		ctx.IsGitRepo = true
-		ctx.Name = gitInfo.RepoName
-		ctx.Branch = gitInfo.Branch
+		ctx.Name = config.SanitizeName(gitInfo.RepoName)
+		ctx.Branch = config.SanitizeName(gitInfo.Branch)
 		ctx.Root = gitInfo.Root
 		ctx.OdooVersion = git.VersionFromBranch(gitInfo.Branch)
 	}

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -143,6 +143,8 @@ func isVersion18OrHigher(version string) bool {
 		return true // default to modern
 	}
 	var major int
-	fmt.Sscanf(version, "%d", &major)
+	if _, err := fmt.Sscanf(version, "%d", &major); err != nil {
+		return true // default to modern on parse error
+	}
 	return major >= 18
 }

--- a/internal/templates/files/12.0/Dockerfile.tmpl
+++ b/internal/templates/files/12.0/Dockerfile.tmpl
@@ -106,9 +106,10 @@ RUN pip3 install --no-cache-dir \
 {{if .Enterprise}}
 # Clone Odoo Enterprise
 {{if .EnterpriseGitHubToken}}
-# Using GitHub Personal Access Token
-RUN git clone --depth 1 --branch {{.OdooVersion}} \
-    https://{{.EnterpriseGitHubToken}}@github.com/odoo/enterprise.git /mnt/enterprise && \
+# Using GitHub Personal Access Token (mounted as build secret)
+RUN --mount=type=secret,id=github_token bash -c 'GITHUB_TOKEN=$(cat /run/secrets/github_token) && \
+    git clone --depth 1 --branch {{.OdooVersion}} \
+    https://${GITHUB_TOKEN}@github.com/odoo/enterprise.git /mnt/enterprise' && \
     chown -R odoo:odoo /mnt/enterprise && \
     chmod -R 755 /mnt/enterprise
 {{else if .EnterpriseSSHKeyPath}}

--- a/internal/templates/files/13.0/Dockerfile.tmpl
+++ b/internal/templates/files/13.0/Dockerfile.tmpl
@@ -105,9 +105,10 @@ RUN pip3 install --no-cache-dir \
 {{if .Enterprise}}
 # Clone Odoo Enterprise
 {{if .EnterpriseGitHubToken}}
-# Using GitHub Personal Access Token
-RUN git clone --depth 1 --branch {{.OdooVersion}} \
-    https://{{.EnterpriseGitHubToken}}@github.com/odoo/enterprise.git /mnt/enterprise && \
+# Using GitHub Personal Access Token (mounted as build secret)
+RUN --mount=type=secret,id=github_token bash -c 'GITHUB_TOKEN=$(cat /run/secrets/github_token) && \
+    git clone --depth 1 --branch {{.OdooVersion}} \
+    https://${GITHUB_TOKEN}@github.com/odoo/enterprise.git /mnt/enterprise' && \
     chown -R odoo:odoo /mnt/enterprise && \
     chmod -R 755 /mnt/enterprise
 {{else if .EnterpriseSSHKeyPath}}

--- a/internal/templates/files/14.0/Dockerfile.tmpl
+++ b/internal/templates/files/14.0/Dockerfile.tmpl
@@ -79,9 +79,10 @@ RUN pip3 install --no-cache-dir \
 {{if .Enterprise}}
 # Clone Odoo Enterprise
 {{if .EnterpriseGitHubToken}}
-# Using GitHub Personal Access Token
-RUN git clone --depth 1 --branch {{.OdooVersion}} \
-    https://{{.EnterpriseGitHubToken}}@github.com/odoo/enterprise.git /mnt/enterprise && \
+# Using GitHub Personal Access Token (mounted as build secret)
+RUN --mount=type=secret,id=github_token bash -c 'GITHUB_TOKEN=$(cat /run/secrets/github_token) && \
+    git clone --depth 1 --branch {{.OdooVersion}} \
+    https://${GITHUB_TOKEN}@github.com/odoo/enterprise.git /mnt/enterprise' && \
     chown -R odoo:odoo /mnt/enterprise && \
     chmod -R 755 /mnt/enterprise
 {{else if .EnterpriseSSHKeyPath}}

--- a/internal/templates/files/15.0/Dockerfile.tmpl
+++ b/internal/templates/files/15.0/Dockerfile.tmpl
@@ -79,9 +79,10 @@ RUN pip3 install --no-cache-dir \
 {{if .Enterprise}}
 # Clone Odoo Enterprise
 {{if .EnterpriseGitHubToken}}
-# Using GitHub Personal Access Token
-RUN git clone --depth 1 --branch {{.OdooVersion}} \
-    https://{{.EnterpriseGitHubToken}}@github.com/odoo/enterprise.git /mnt/enterprise && \
+# Using GitHub Personal Access Token (mounted as build secret)
+RUN --mount=type=secret,id=github_token bash -c 'GITHUB_TOKEN=$(cat /run/secrets/github_token) && \
+    git clone --depth 1 --branch {{.OdooVersion}} \
+    https://${GITHUB_TOKEN}@github.com/odoo/enterprise.git /mnt/enterprise' && \
     chown -R odoo:odoo /mnt/enterprise && \
     chmod -R 755 /mnt/enterprise
 {{else if .EnterpriseSSHKeyPath}}

--- a/internal/templates/files/16.0/Dockerfile.tmpl
+++ b/internal/templates/files/16.0/Dockerfile.tmpl
@@ -93,9 +93,10 @@ RUN pip3 install --no-cache-dir \
 {{if .Enterprise}}
 # Clone Odoo Enterprise
 {{if .EnterpriseGitHubToken}}
-# Using GitHub Personal Access Token
-RUN git clone --depth 1 --branch {{.OdooVersion}} \
-    https://{{.EnterpriseGitHubToken}}@github.com/odoo/enterprise.git /mnt/enterprise && \
+# Using GitHub Personal Access Token (mounted as build secret)
+RUN --mount=type=secret,id=github_token bash -c 'GITHUB_TOKEN=$(cat /run/secrets/github_token) && \
+    git clone --depth 1 --branch {{.OdooVersion}} \
+    https://${GITHUB_TOKEN}@github.com/odoo/enterprise.git /mnt/enterprise' && \
     chown -R odoo:odoo /mnt/enterprise && \
     chmod -R 755 /mnt/enterprise
 {{else if .EnterpriseSSHKeyPath}}

--- a/internal/templates/files/17.0/Dockerfile.tmpl
+++ b/internal/templates/files/17.0/Dockerfile.tmpl
@@ -93,9 +93,10 @@ RUN pip3 install --no-cache-dir \
 {{if .Enterprise}}
 # Clone Odoo Enterprise
 {{if .EnterpriseGitHubToken}}
-# Using GitHub Personal Access Token
-RUN git clone --depth 1 --branch {{.OdooVersion}} \
-    https://{{.EnterpriseGitHubToken}}@github.com/odoo/enterprise.git /mnt/enterprise && \
+# Using GitHub Personal Access Token (mounted as build secret)
+RUN --mount=type=secret,id=github_token bash -c 'GITHUB_TOKEN=$(cat /run/secrets/github_token) && \
+    git clone --depth 1 --branch {{.OdooVersion}} \
+    https://${GITHUB_TOKEN}@github.com/odoo/enterprise.git /mnt/enterprise' && \
     chown -R odoo:odoo /mnt/enterprise && \
     chmod -R 755 /mnt/enterprise
 {{else if .EnterpriseSSHKeyPath}}

--- a/internal/templates/files/19.0/Dockerfile.tmpl
+++ b/internal/templates/files/19.0/Dockerfile.tmpl
@@ -93,9 +93,10 @@ RUN pip3 install --no-cache-dir --break-system-packages \
 {{if .Enterprise}}
 # Clone Odoo Enterprise
 {{if .EnterpriseGitHubToken}}
-# Using GitHub Personal Access Token
-RUN git clone --depth 1 --branch {{.OdooVersion}} \
-    https://{{.EnterpriseGitHubToken}}@github.com/odoo/enterprise.git /mnt/enterprise && \
+# Using GitHub Personal Access Token (mounted as build secret)
+RUN --mount=type=secret,id=github_token bash -c 'GITHUB_TOKEN=$(cat /run/secrets/github_token) && \
+    git clone --depth 1 --branch {{.OdooVersion}} \
+    https://${GITHUB_TOKEN}@github.com/odoo/enterprise.git /mnt/enterprise' && \
     chown -R odoo:odoo /mnt/enterprise && \
     chmod -R 755 /mnt/enterprise
 {{else if .EnterpriseSSHKeyPath}}

--- a/internal/templates/files/Dockerfile.tmpl
+++ b/internal/templates/files/Dockerfile.tmpl
@@ -93,9 +93,10 @@ RUN pip3 install --no-cache-dir --break-system-packages \
 {{if .Enterprise}}
 # Clone Odoo Enterprise
 {{if .EnterpriseGitHubToken}}
-# Using GitHub Personal Access Token
-RUN git clone --depth 1 --branch {{.OdooVersion}} \
-    https://{{.EnterpriseGitHubToken}}@github.com/odoo/enterprise.git /mnt/enterprise && \
+# Using GitHub Personal Access Token (mounted as build secret)
+RUN --mount=type=secret,id=github_token bash -c 'GITHUB_TOKEN=$(cat /run/secrets/github_token) && \
+    git clone --depth 1 --branch {{.OdooVersion}} \
+    https://${GITHUB_TOKEN}@github.com/odoo/enterprise.git /mnt/enterprise' && \
     chown -R odoo:odoo /mnt/enterprise && \
     chmod -R 755 /mnt/enterprise
 {{else if .EnterpriseSSHKeyPath}}

--- a/internal/templates/files/docker-compose.yml.tmpl
+++ b/internal/templates/files/docker-compose.yml.tmpl
@@ -4,10 +4,13 @@ x-odoo-common: &odoo-common
     context: .
     dockerfile: Dockerfile
 {{- if .Enterprise}}
-{{- if .EnterpriseSSHKeyPath}}
+{{- if .EnterpriseGitHubToken}}
+    secrets:
+      - github_token
+{{- else if .EnterpriseSSHKeyPath}}
     secrets:
       - enterprise_ssh_key
-{{- else if not .EnterpriseGitHubToken}}
+{{- else}}
     ssh:
       - default
 {{- end}}
@@ -99,9 +102,16 @@ volumes:
   odoo-postgres-data-{{.VersionSuffix}}:
   odoo-filestore-{{.VersionSuffix}}:
   odoo-sessions-{{.VersionSuffix}}:
-{{- if and .Enterprise .EnterpriseSSHKeyPath}}
+{{- if .Enterprise}}
+{{- if .EnterpriseGitHubToken}}
+
+secrets:
+  github_token:
+    environment: GITHUB_TOKEN
+{{- else if .EnterpriseSSHKeyPath}}
 
 secrets:
   enterprise_ssh_key:
     file: {{.EnterpriseSSHKeyPath}}
+{{- end}}
 {{- end}}


### PR DESCRIPTION
Security fixes (High Priority):
- Fix #10: Change state file permissions from 0644 to 0600 for GitHub token security
- Fix #11: Use BuildKit secrets instead of build args for GitHub tokens in Dockerfiles
  - Updated all 8 version-specific Dockerfile templates (12.0-19.0 + default)
  - Modified docker-compose.yml.tmpl to pass token as secret via environment
  - Updated internal/docker/docker.go to pass GITHUB_TOKEN environment variable

Refactoring (Medium Priority):
- Fix #13: Add State.DBName() method and replace 6 duplicated implementations
- Fix #14: Move expandPath and maskToken to shared location (internal/config/util.go)
- Fix #15: Replace fmt.Scanln with pkg/prompt consistently in 4 locations
- Fix #16: Remove unused dockerRoot code in create.go

Enhancements (Low Priority):
- Fix #17: Optimize LoadFromDir performance with marker file for O(1) lookup
- Fix #18: Add sanitization for project and branch names (handles special chars)
- Fix #19: Add checksum verification to install.sh with make checksums target
- Fix #20: Add error handling for docker compose down in reset command
- Fix #21: Add golangci-lint to Makefile with .golangci.yml configuration

Additional improvements:
- Fix demo data inversion for Odoo v19+ (added version detection logic)
- Fix all golangci-lint issues (errcheck, ineffassign, etc.)
- Update deprecated golangci-lint configuration options
